### PR TITLE
Allow the use of Hashie v3

### DIFF
--- a/kounta.gemspec
+++ b/kounta.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "0.9.12.2"
 
   spec.add_dependency "oj", "~> 2"
-  spec.add_dependency "hashie", "~> 2"
+  spec.add_dependency "hashie", ">= 2", "< 4"
   spec.add_dependency "oauth2", "~> 1"
   spec.add_dependency "faraday_middleware", "~> 0.9"
 end

--- a/lib/kounta/resource.rb
+++ b/lib/kounta/resource.rb
@@ -4,6 +4,7 @@ require_relative "rest/client"
 module Kounta
 
 	class Resource < Hashie::Dash
+		include Hashie::Extensions::Dash::IndifferentAccess if defined?(Hashie::Extensions::Dash::IndifferentAccess)
 		include Hashie::Extensions::Coercion
 
 		attr_accessor :client


### PR DESCRIPTION
Use `Hashie::Extensions::Dash::IndifferentAccess` to keep APIs the same.